### PR TITLE
Dev/thetonyho/fix empty classes

### DIFF
--- a/builder/PyStubbler/PyStubbler.csproj
+++ b/builder/PyStubbler/PyStubbler.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <StartArguments>--dest=".\Rhino" --search="C:\\Program Files\\Rhino 7\\System" "C:\\Program Files\\Rhino 7\\System\\RhinoCommon.dll"</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\bin\</OutputPath>

--- a/builder/PyStubblerLib/StubBuilder.cs
+++ b/builder/PyStubblerLib/StubBuilder.cs
@@ -197,6 +197,8 @@ namespace PyStubblerLib
                 else
                     sb.AppendLine($"class {stubType.Name}:");
 
+                string classStartString = sb.ToString();
+
                 // constructors
                 ConstructorInfo[] constructors = stubType.GetConstructors();
                 // sort for consistent output
@@ -326,6 +328,12 @@ namespace PyStubblerLib
                     }
                     sb.AppendLine(": ...");
                 }
+                // If no strings appended, class is empty. add "pass"
+                if (sb.ToString().Length == classStartString.Length)
+                {
+                    sb.AppendLine($"    pass");
+                }
+
             }
             File.WriteAllText(path, sb.ToString());
         }


### PR DESCRIPTION
I noticed there is a bug as it was unsuccessfully autocomplete `Rhino.Geometry.Transform`
This is caused by the `class SurfaceProxy(Surface)` not property defined on line: 5162. 

```python
...

class SurfaceProxy(Surface):
    pass # added for empty classes


class SweepOneRail:
    def __init__(self): ...

...
```

This fixes the empty classes and allow autocomplete for the entire stubs
![image](https://user-images.githubusercontent.com/1776289/118571419-522a3100-b7c1-11eb-8ccd-8ac4499c752a.png)
