### PR TITLE
Make type checkers recognize overload signature

### DIFF
--- a/builder/PyStubblerLib/StubBuilder.cs
+++ b/builder/PyStubblerLib/StubBuilder.cs
@@ -159,7 +159,7 @@ namespace PyStubblerLib
                 }
                 sb.AppendLine("]");
             }
-            sb.AppendLine("from typing import Tuple, Set, Iterable, List");
+            sb.AppendLine("from typing import Tuple, Set, Iterable, List, overload");
 
             foreach (var stubType in stubTypes)
             {

--- a/builder/PythonStubsBuilder.cs
+++ b/builder/PythonStubsBuilder.cs
@@ -85,7 +85,7 @@ namespace PythonStubs {
             path = Path.Combine(path, "__init__.pyi");
 
             var sb = new System.Text.StringBuilder();
-            sb.AppendLine("from typing import Tuple, Set, Iterable, List");
+            sb.AppendLine("from typing import Tuple, Set, Iterable, List, overload");
 
             foreach (var stubType in stubTypes) {
                 sb.AppendLine();

--- a/stubs/Eto/Eto-stubs/Drawing/__init__.pyi
+++ b/stubs/Eto/Eto-stubs/Drawing/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Bitmap(Image):

--- a/stubs/Eto/Eto-stubs/Forms/ThemedControls/__init__.pyi
+++ b/stubs/Eto/Eto-stubs/Forms/ThemedControls/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ThemedAboutDialogHandler:

--- a/stubs/Eto/Eto-stubs/Forms/__init__.pyi
+++ b/stubs/Eto/Eto-stubs/Forms/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['ThemedControls']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AboutDialog(CommonDialog):

--- a/stubs/Eto/Eto-stubs/IO/__init__.pyi
+++ b/stubs/Eto/Eto-stubs/IO/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class IconSize:

--- a/stubs/Eto/Eto-stubs/Threading/__init__.pyi
+++ b/stubs/Eto/Eto-stubs/Threading/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ICallback:

--- a/stubs/Eto/Eto-stubs/__init__.pyi
+++ b/stubs/Eto/Eto-stubs/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Drawing','Forms','IO','Threading']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AttachableMemberIdentifier:

--- a/stubs/GH_IO/GH_IO-stubs/Serialization/__init__.pyi
+++ b/stubs/GH_IO/GH_IO-stubs/Serialization/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ChunkKeyedCollection:

--- a/stubs/GH_IO/GH_IO-stubs/Types/__init__.pyi
+++ b/stubs/GH_IO/GH_IO-stubs/Types/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_BoundingBox:

--- a/stubs/GH_IO/GH_IO-stubs/UserInterface/__init__.pyi
+++ b/stubs/GH_IO/GH_IO-stubs/UserInterface/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_ArchiveMessageViewer:

--- a/stubs/GH_IO/GH_IO-stubs/__init__.pyi
+++ b/stubs/GH_IO/GH_IO-stubs/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Serialization','Types','UserInterface']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Branch:

--- a/stubs/GH_Util/GH_Util-stubs/MetaBall/__init__.pyi
+++ b/stubs/GH_Util/GH_Util-stubs/MetaBall/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class FieldSolver:

--- a/stubs/GH_Util/GH_Util-stubs/__init__.pyi
+++ b/stubs/GH_Util/GH_Util-stubs/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['MetaBall']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BezierF:

--- a/stubs/Grasshopper/Grasshopper-stubs/Documentation/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Documentation/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_Audience:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Alignment/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Alignment/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_Align:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Base/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Base/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ColorChangedEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Canvas/Interaction/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Canvas/Interaction/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_AbstractInteraction:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Canvas/TagArtists/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Canvas/TagArtists/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_TagArtist:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Canvas/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Canvas/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Interaction','TagArtists']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CanvasPaintBackgroundEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Colours/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Colours/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_ColourBucket:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Equations/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Equations/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_EquationFragment:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Gradient/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Gradient/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_Gradient:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/HTML/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/HTML/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_CssConstants:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/IconEditor/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/IconEditor/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_IconObject:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Layout/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Layout/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_GenericLayout:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/MRU/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/MRU/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class FileSelectedEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/RemotePanel/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/RemotePanel/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class EditModeChangedEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Ribbon/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Ribbon/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_Layout:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Script/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Script/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CompileCodeRequestEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/SettingsControls/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/SettingsControls/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_AlignWidgetFrontEnd:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Stacks/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Stacks/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_Interpolation:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/StringDisplay/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/StringDisplay/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_FormattedListItem(GH_SimpleListItem):

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Theme/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Theme/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_BackgroundSettings:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/Widgets/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/Widgets/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class DockCornerChangedEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/GUI/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/GUI/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Alignment','Base','Canvas','Colours','Equations','Gradient','HTML','IconEditor','Layout','MRU','RemotePanel','Ribbon','Script','SettingsControls','Stacks','StringDisplay','Theme','Widgets']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AggregateShortcutMenuItemsEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/Getters/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Getters/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_ArcGetter:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Attributes/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Attributes/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_ComponentAttributes:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Components/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Components/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BufferMode:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Data/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Data/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Expressions/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Expressions/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_CharType:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/ConvexHull/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/ConvexHull/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Solver:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/Delaunay/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/Delaunay/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Connectivity:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/SpatialTrees/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/SpatialTrees/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/Voronoi/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/Voronoi/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Cell2:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Geometry/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['ConvexHull','Delaunay','SpatialTrees','Voronoi']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Circle2:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Graphs/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Graphs/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_AbstractGraph:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Parameters/Hints/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Parameters/Hints/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_ArcHint:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Parameters/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Parameters/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Hints']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Sorting/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Sorting/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_NetworkSorter:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Special/SketchElements/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Special/SketchElements/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_SketchBox:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Special/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Special/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['SketchElements']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Alignment:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Types/Transforms/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Types/Transforms/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Generic:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Types/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Types/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Transforms']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Complex:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Undo/Actions/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Undo/Actions/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_AddObjectAction(GH_UndoAction):

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Undo/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Undo/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Actions']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_ArchivedUndoAction(GH_UndoAction):

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/Utility/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/Utility/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GH_Interval_Wrapper:

--- a/stubs/Grasshopper/Grasshopper-stubs/Kernel/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Kernel/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Attributes','Components','Data','Expressions','Geometry','Graphs','Parameters','Sorting','Special','Types','Undo','Utility']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AttributesChangedEventHandler:

--- a/stubs/Grasshopper/Grasshopper-stubs/Plugin/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/Plugin/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Commands:

--- a/stubs/Grasshopper/Grasshopper-stubs/__init__.pyi
+++ b/stubs/Grasshopper/Grasshopper-stubs/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Documentation','Getters','GUI','Kernel','Plugin']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AuthorAddressChangedEventHandler:

--- a/stubs/Rhino/Rhino-stubs/ApplicationSettings/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/ApplicationSettings/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AppearanceSettings:

--- a/stubs/Rhino/Rhino-stubs/Collections/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Collections/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ArchivableDictionary:

--- a/stubs/Rhino/Rhino-stubs/Commands/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Commands/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class Command:

--- a/stubs/Rhino/Rhino-stubs/Display/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Display/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AnalysisStyle:

--- a/stubs/Rhino/Rhino-stubs/DocObjects/Custom/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/DocObjects/Custom/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ClassIdAttribute:

--- a/stubs/Rhino/Rhino-stubs/DocObjects/SnapShots/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/DocObjects/SnapShots/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class SnapShotsClient:

--- a/stubs/Rhino/Rhino-stubs/DocObjects/Tables/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/DocObjects/Tables/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BitmapTable:

--- a/stubs/Rhino/Rhino-stubs/DocObjects/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/DocObjects/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Custom','SnapShots','Tables']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ActiveSpace:

--- a/stubs/Rhino/Rhino-stubs/FileIO/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/FileIO/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AsciiEol:

--- a/stubs/Rhino/Rhino-stubs/Geometry/Collections/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Geometry/Collections/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BrepCurveList:

--- a/stubs/Rhino/Rhino-stubs/Geometry/Intersect/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Geometry/Intersect/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CurveIntersections:

--- a/stubs/Rhino/Rhino-stubs/Geometry/MeshRefinements/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Geometry/MeshRefinements/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CreaseEdges:

--- a/stubs/Rhino/Rhino-stubs/Geometry/Morphs/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Geometry/Morphs/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BendSpaceMorph(SpaceMorph):

--- a/stubs/Rhino/Rhino-stubs/Geometry/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Geometry/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Collections','Intersect','MeshRefinements','Morphs']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AngularDimension(Dimension):

--- a/stubs/Rhino/Rhino-stubs/Input/Custom/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Input/Custom/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CommandLineOption:

--- a/stubs/Rhino/Rhino-stubs/Input/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Input/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Custom']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BitmapFileTypes:

--- a/stubs/Rhino/Rhino-stubs/NodeInCode/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/NodeInCode/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ComponentFunctionInfo:

--- a/stubs/Rhino/Rhino-stubs/PlugIns/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/PlugIns/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CustomRenderSaveFileTypes:

--- a/stubs/Rhino/Rhino-stubs/Render/ChangeQueue/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/ChangeQueue/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BakingFunctions:

--- a/stubs/Rhino/Rhino-stubs/Render/ChildSlotNames/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/ChildSlotNames/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class PhysicallyBased:

--- a/stubs/Rhino/Rhino-stubs/Render/DataSources/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/DataSources/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AssignBys:

--- a/stubs/Rhino/Rhino-stubs/Render/Fields/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/Fields/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class BoolField(Field):

--- a/stubs/Rhino/Rhino-stubs/Render/ParameterNames/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/ParameterNames/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class PhysicallyBased:

--- a/stubs/Rhino/Rhino-stubs/Render/PostEffects/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/PostEffects/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CustomPostEffectAttribute:

--- a/stubs/Rhino/Rhino-stubs/Render/UI/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/UI/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class WorldMapDayNight:

--- a/stubs/Rhino/Rhino-stubs/Render/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Render/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['ChangeQueue','ChildSlotNames','DataSources','Fields','ParameterNames','PostEffects','UI']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AsyncRenderContext:

--- a/stubs/Rhino/Rhino-stubs/Runtime/InProcess/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Runtime/InProcess/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class RhinoCore:

--- a/stubs/Rhino/Rhino-stubs/Runtime/InteropWrappers/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Runtime/InteropWrappers/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ClassArrayObjRef:

--- a/stubs/Rhino/Rhino-stubs/Runtime/Notifications/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Runtime/Notifications/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class ButtonType:

--- a/stubs/Rhino/Rhino-stubs/Runtime/RhinoAccounts/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Runtime/RhinoAccounts/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class IOAuth2Token:

--- a/stubs/Rhino/Rhino-stubs/Runtime/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/Runtime/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['InProcess','InteropWrappers','Notifications','RhinoAccounts']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AdvancedSetting:

--- a/stubs/Rhino/Rhino-stubs/UI/Controls/DataSource/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/UI/Controls/DataSource/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class EventArgs:

--- a/stubs/Rhino/Rhino-stubs/UI/Controls/ThumbnailUI/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/UI/Controls/ThumbnailUI/__init__.pyi
@@ -1,1 +1,1 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload

--- a/stubs/Rhino/Rhino-stubs/UI/Controls/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/UI/Controls/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['DataSource','ThumbnailUI']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CollapsibleSectionHolderImpl:

--- a/stubs/Rhino/Rhino-stubs/UI/Gumball/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/UI/Gumball/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class GumballAppearanceSettings:

--- a/stubs/Rhino/Rhino-stubs/UI/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/UI/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['Controls','Gumball']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class CursorStyle:

--- a/stubs/Rhino/Rhino-stubs/__init__.pyi
+++ b/stubs/Rhino/Rhino-stubs/__init__.pyi
@@ -1,5 +1,5 @@
 __all__ = ['ApplicationSettings','Collections','Commands','Display','DocObjects','FileIO','Geometry','Input','NodeInCode','PlugIns','Render','Runtime','UI']
-from typing import Tuple, Set, Iterable, List
+from typing import Tuple, Set, Iterable, List, overload
 
 
 class AngleUnitSystem:


### PR DESCRIPTION
This is a simple PR that makes type checkers such as Pyright and Mypy recognize overload method signatures.

Currently, overload decorators are not working because they're not imported properly.

![image](https://github.com/user-attachments/assets/8177d53e-a43e-49a2-afa8-450a3b4db9dd)
![image](https://github.com/user-attachments/assets/3c806f28-732b-4a1a-90f4-29b4188d6ecb)
