### PR TITLE
Make type checkers recognize operator methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This is a fork of the original `mcneel/pythonstubs` repository, intended for use by Edit Collective.
+
 # McNeel python stubs
 
 [![PyPI](https://img.shields.io/pypi/v/Rhino-stubs.svg)](https://pypi.org/project/Rhino-stubs)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This is a fork of the original `mcneel/pythonstubs` repository, intended for use by Edit Collective.
+> This is a fork of the original `mcneel/pythonstubs` repository, intended for use by Edit Collective. Modifications are currently focused on improving type hint support.
 
 # McNeel python stubs
 

--- a/builder/PyStubblerLib/StubBuilder.cs
+++ b/builder/PyStubblerLib/StubBuilder.cs
@@ -268,6 +268,62 @@ namespace PyStubblerLib
                         }
                         sb.Append($"    def {propName}(");
                     }
+                    else if (method.Name.StartsWith("op_")) {
+                        if (methodNames[method.Name] > 1)
+                            sb.AppendLine("    @overload");
+                        string propName;
+                        if (method.Name == "op_Equality") 
+                            propName = "__eq__";
+                        else if (method.Name == "op_Inequality") 
+                            propName = "__ne__";
+                        else if (method.Name == "op_GreaterThan") 
+                            propName = "__gt__";
+                        else if (method.Name == "op_GreaterThanOrEqual") 
+                            propName = "__ge__";
+                        else if (method.Name == "op_LessThan") 
+                            propName = "__lt__";
+                        else if (method.Name == "op_LessThanOrEqual") 
+                            propName = "__le__";
+                        else if (method.Name == "op_Addition") 
+                            propName = "__add__";
+                        else if (method.Name == "op_Subtraction") 
+                            propName = "__sub__";
+                        else if (method.Name == "op_Multiply") 
+                            propName = "__mul__";
+                        else if (method.Name == "op_Division") 
+                            propName = "__truediv__";
+                        else if (method.Name == "op_IntegerDivision") 
+                            propName = "__floordiv__";
+                        else if (method.Name == "op_Modulus") 
+                            propName = "__mod__";
+                        else if (method.Name == "op_Exponent") 
+                            propName = "__pow__";
+                        else if (method.Name == "op_UnaryNegation") 
+                            propName = "__neg__";
+                        else if (method.Name == "op_UnaryPlus") 
+                            propName = "__pos__";
+                        else if (method.Name == "op_BitwiseAnd") 
+                            propName = "__and__";
+                        else if (method.Name == "op_BitwiseOr") 
+                            propName = "__or__";
+                        else if (method.Name == "op_ExclusiveOr") 
+                            propName = "__xor__";
+                        else if (method.Name == "op_Concatenate") 
+                            propName = "__add__";
+                        else if (method.Name == "op_LeftShift") 
+                            propName = "__lshift__";
+                        else if (method.Name == "op_RightShift") 
+                            propName = "__rshift__";
+                        else if (method.Name == "op_OnesComplement") 
+                            propName = "__invert__";
+                        else if (method.Name == "op_False") 
+                            propName = "__bool__";
+                        else if (method.Name == "op_True") 
+                            propName = "__bool__";
+                        else 
+                            propName = method.Name;
+                        sb.Append($"    def {propName}(");
+                    }
                     else
                     {
                         if (methodNames[method.Name] > 1)


### PR DESCRIPTION
This is a PR that converts C# operator methods into those of Python. By doing so, type checkers such as Pyright and Mypy can understand that these classes support specific operators. Currently, operators invoke type errors.

![image](https://github.com/user-attachments/assets/a0fc2119-2eb8-4821-b1d6-1e12c7b36b1f)

I didn't run `.\build-rhino-stubs.ps1` yet because I didn't want to mess up the versioning compatiblity, but I can Run the Powershell script and update the PR if it helps(My PC has Rhino 7.37 and Dotnet 4.8).